### PR TITLE
use docs now in app instead of kabaneroio

### DIFF
--- a/src/main/content/index.html
+++ b/src/main/content/index.html
@@ -30,7 +30,7 @@ seo-title: Kabanero
             <!-- Documentation Link -->
             <div class="row">
                 <div class="col-md">
-                    <p>Please see <a href="https://kabanero.io/docs/">documentation</a> for the next steps in using Kabanero.</p>
+                    <p>Please see <a href="/docs">documentation</a> for the next steps in using Kabanero.</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

switch from kabanero.io/docs to use docs packaged with the landing page now

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
