### PR TITLE
always go to /docs

### DIFF
--- a/src/main/content/_includes/header.html
+++ b/src/main/content/_includes/header.html
@@ -24,7 +24,7 @@
                         <ul class="navbar-nav mr-auto">
                             <li class="nav-item">
                                 <a class="nav-link {% if page.url contains '/instance' %}active-nav{% endif %}" href="/instance">Instance</a>
-                                <a class="nav-link {% if page.url contains '/docs' %}active-nav{% endif %}" href="{{site.site_custom.index.docs_url}}">Docs</a>
+                                <a class="nav-link {% if page.url contains '/docs' %}active-nav{% endif %}" href="/docs">Docs</a>
                                 <a class="nav-link {% if page.url contains '/guides' %}active-nav{% endif %}" href="/guides">Guides</a>
                             </li>
                         </ul>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

no custom link for docs page.

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
