### PR TITLE
design updates

### DIFF
--- a/src/main/content/_assets/css/guide-card.css
+++ b/src/main/content/_assets/css/guide-card.css
@@ -46,7 +46,7 @@ body {
 
 .guide_item:hover, .small_guide_item:hover {
     box-shadow:0 2px 4px 0 rgba(63,70,89,0.59);
-    border-left: solid 0.3em #C43804;
+    border-color: #C43804;
 }
 
 .guide_title_and_description_container {


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Closes #43 

The border-left style on the guide cards is 9px unless you hover on it. This PR changes the value on hover from shortening to 0.3em; the size of the border-left now stays the same on hover while the color toggles from gray to orange.