### PR TITLE
Fixed bug with sidebar

### DIFF
--- a/src/main/content/_assets/css/side-bar.scss
+++ b/src/main/content/_assets/css/side-bar.scss
@@ -141,3 +141,7 @@ a.bx--side-nav__link:focus {
 .modal-copy {
     max-width: 3em;
 }
+
+.hamburger-svg{
+    max-height:100%;
+}

--- a/src/main/content/_includes/side-bar.html
+++ b/src/main/content/_includes/side-bar.html
@@ -4,7 +4,7 @@
 <aside class="bx--side-nav" data-side-nav>
     <nav class="bx--side-nav__navigation" role="navigation" aria-label="Side navigation">
         <header class="bx--side-nav__header bx--side-nav__toggle">
-            <svg>
+            <svg class="hamburger-svg">
                 <use xlink:href="/img/carbon-icons/carbon-icons.svg#icon--header--hamburger"></use>
             </svg>
         </header>

--- a/src/main/content/_layouts/guide-multipane.html
+++ b/src/main/content/_layouts/guide-multipane.html
@@ -1,19 +1,21 @@
 ---
 layout: default
 css:
-- header
 - toc
 - end-of-guide
 - guide-card
 - guide
 - guide-multipane
+- header
 - side-bar
 js:
 - guide-utils
 - toc
 - guide
 - guide-multipane
+- header
 - side-bar
+- thirdparty/carbon/carbon-components.min
 ---
 
 <!-----------------------------------------------------------------------------

--- a/src/main/content/_layouts/guide.html
+++ b/src/main/content/_layouts/guide.html
@@ -11,6 +11,7 @@ js:
 - guide-utils
 - toc
 - guide
+- header
 - side-bar
 - thirdparty/carbon/carbon-components.min
 ---

--- a/src/main/content/_layouts/guide.html
+++ b/src/main/content/_layouts/guide.html
@@ -1,11 +1,11 @@
 ---
 layout: default
 css:
-- header
 - toc
 - end-of-guide
 - guide-card
 - guide
+- header
 - side-bar
 js:
 - guide-utils

--- a/src/main/content/guides.html
+++ b/src/main/content/guides.html
@@ -4,8 +4,12 @@ title: Guides
 css:
 - guide-card
 - guides
+- header
+- side-bar
 js: 
 - guides
+- header
+- side-bar
 permalink: /guides/
 ---
 {% assign t = site.data[site.active_lang].guides %}


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
This PR fixes a bug in the guides page where the `svg` tag that contains the icon for expanding the sidebar is too large and overlaps the home icon in the sidebar.  This was causing the sidebar to expand when a user clicked on the home icon from a guide.  