### PR TITLE
Instance loading refactor

### DIFF
--- a/src/main/content/_assets/css/instance.scss
+++ b/src/main/content/_assets/css/instance.scss
@@ -153,3 +153,7 @@ button:disabled > .arrow-container > svg{
 #collection-list li {
     margin-top: 1em;
 }
+
+#blank-row{
+    display:none;
+}

--- a/src/main/content/_assets/js/instance-common.js
+++ b/src/main/content/_assets/js/instance-common.js
@@ -146,8 +146,8 @@ let InstancePane = class {
         let copyImgWrapper = $("<div/>", {class: "input-group-append"});
         copyImgWrapper.append(img);
 
-        let input = $("<input/>", {id, type: "text", class: "form-control collection-hub-input tooltip-copy", readonly: "readonly", onClick: "this.select();", value: "Copied!"}) 
-            .tooltip({title: "Copied!", container: "body", placement: "top", trigger: "hover"});
+        let input = $("<input/>", {id, type: "text", class: "form-control collection-hub-input tooltip-copy", readonly: "readonly", onClick: "this.select();", value: url}) 
+            .tooltip({title: url, container: "body", placement: "top", trigger: "hover"});
         return wrapper.append(input, copyImgWrapper);
     }
 

--- a/src/main/content/_assets/js/instance-common.js
+++ b/src/main/content/_assets/js/instance-common.js
@@ -24,7 +24,7 @@ function fetchAllInstances(){
         .catch(error => console.error("Error getting instance names:", error));
 }
 
-function fetchAInstance(instance){
+function fetchAnInstance(instance){
     return fetch(`/api/instances/${instance}`)
         .then(function(response) {
             return response.json();
@@ -146,8 +146,8 @@ let InstancePane = class {
         let copyImgWrapper = $("<div/>", {class: "input-group-append"});
         copyImgWrapper.append(img);
 
-        let input = $("<input/>", {id, type: "text", class: "form-control collection-hub-input tooltip-copy", readonly: "readonly", onClick: "this.select();", value: url}) 
-            .tooltip({title: url, container: "body", placement: "top", trigger: "hover"});
+        let input = $("<input/>", {id, type: "text", class: "form-control collection-hub-input tooltip-copy", readonly: "readonly", onClick: "this.select();", value: "Copied!"}) 
+            .tooltip({title: "Copied!", container: "body", placement: "top", trigger: "hover"});
         return wrapper.append(input, copyImgWrapper);
     }
 

--- a/src/main/content/_assets/js/instance.js
+++ b/src/main/content/_assets/js/instance.js
@@ -58,7 +58,6 @@ function setInstanceNames(instances){
         setErrorHTML();
         return;
     }
-    console.log(instances);
     for(let instance of instances){
         let details = instance.details || {};
         let dateCreated = details.dateCreated;
@@ -148,8 +147,6 @@ function setToolData(tools){
 }
 
 function handleInstanceSelection(element){
-    console.log("handling instance selection");
-    console.log(element);
     //return if clicked element is already open and the collections card doesn"t need to be updated
     if($(element).attr("aria-expanded") === "true"){
         return;
@@ -158,13 +155,10 @@ function handleInstanceSelection(element){
     $(".bx--accordion__heading").attr("aria-expanded", false);
     $(".bx--accordion__heading").parent().removeClass("bx--accordion__item--active");
     let selectedInstanceName = $(element).find(".bx--accordion__title").text().trim();
-    console.log(selectedInstanceName);
     fetchAnInstance(selectedInstanceName).then(updateInstanceView);
 }
 
 function updateInstanceView(instanceJSON){
-    console.log("updating instance view");
-    console.log(instanceJSON);
     //update the collections card
     let details = instanceJSON.details;
     let appHubName = details.repos[0].name;
@@ -190,12 +184,8 @@ function updateInstanceView(instanceJSON){
     $("#collection-details-card #num-collections").text(numberOfCollections);
     let liColls = "";
     $(collections).each(function(){
-        console.log(liColls);
-        console.log("appending VVV");
-        console.log(this.name);
         liColls = liColls.concat(`<li>${this.name} : ${this.version}</li>`);
     });
-    console.log(liColls);
 
     $("#collection-details-card #collection-list").html(`<ul>${liColls}</ul>`);
 

--- a/src/main/content/_assets/js/instance.js
+++ b/src/main/content/_assets/js/instance.js
@@ -23,14 +23,30 @@ $(document).ready(function() {
 
 function setListeners(){
     // event delegation for dynamic collection hub input copy
-    $(document).on("click", ".collection-hub-input", function(){
-        $(this).siblings(".input-group-append").children(".tooltip-copy").tooltip("show");
-        copy($(this));
+    $(document).on("mouseover", ".collection-hub-input", function(){
+        $(this).attr("data-original-title", $(this).attr("data-original-title"));
+        $(this).tooltip("show");
+        //copy($(this));
+    });
+
+    $(document).on("mouseout", ".collection-hub-input", function(){
+        $(this).tooltip("hide");
+    });
+
+    $(document).on("mouseover", ".copy-to-clipboard", function(){
+        $(this).attr("data-original-title", $(this).attr("data-copy-text"));
+        $(this).tooltip("show");
+        //copy($(this));
+    });
+
+    $(document).on("mouseout", ".copy-to-clipboard", function(){
+        $(this).tooltip("hide");
     });
 
     $(document).on("click", ".copy-to-clipboard", function(){
-        $(this).tooltip("show");
         copy($(this).parent().siblings(".collection-hub-input"));
+        $(this).attr("data-original-title", "Copied!");
+        $(this).tooltip("show");
     });
 
     function copy(input){
@@ -171,14 +187,14 @@ function updateInstanceView(instanceJSON){
     // Instance Details
     $("#instance-details-card #apphub-name").text(appHubName);
 
-    $("#instance-details-card #appsody-url").val(appsodyURL).attr("data-original-title", appsodyURL).attr("title", appsodyURL);
-    $("#instance-details-card #appsody-url").next(".input-group-append").children(".tooltip-copy").attr("data-original-title", "Copied!");
+    $("#instance-details-card #appsody-url").val(appsodyURL).attr("data-original-title", appsodyURL)
+    $("#instance-details-card #appsody-url").next(".input-group-append").children(".tooltip-copy").attr("data-copy-text", "Click to copy Appsody URL");
 
-    $("#instance-details-card #codewind-url").val(codewindURL).attr("data-original-title", codewindURL).attr("title", codewindURL);
-    $("#instance-details-card #codewind-url").next(".input-group-append").children(".tooltip-copy").attr("data-original-title", "Copied!");
+    $("#instance-details-card #codewind-url").val(codewindURL).attr("data-original-title", codewindURL)
+    $("#instance-details-card #codewind-url").next(".input-group-append").children(".tooltip-copy").attr("data-copy-text", "Click to copy Codewind URL");
 
-    $("#instance-details-card #management-cli").val(cliURL).attr("data-original-title", cliURL).attr("title", cliURL);
-    $("#instance-details-card #management-cli").next(".input-group-append").children(".tooltip-copy").attr("data-original-title", "Copied!");
+    $("#instance-details-card #management-cli").val(cliURL).attr("data-original-title", cliURL)
+    $("#instance-details-card #management-cli").next(".input-group-append").children(".tooltip-copy").attr("data-copy-text", "Click to copy Management CLI URL");
 
     // Collections Card
     $("#collection-details-card #num-collections").text(numberOfCollections);

--- a/src/main/content/_assets/js/side-bar.js
+++ b/src/main/content/_assets/js/side-bar.js
@@ -12,7 +12,6 @@ function handleSideNav() {
         let $sideNav = $("aside.bx--side-nav");
         
         if ($sideNav.hasClass("bx--side-nav--expanded") && $(e.target).parents("aside.bx--side-nav").length === 0) {
-            console.log("closing");
             $sideNav.removeClass("bx--side-nav--expanded");
         }
     });

--- a/src/main/content/instance.html
+++ b/src/main/content/instance.html
@@ -40,6 +40,26 @@ permalink: /instance/
                     </div>
                 </button>
                 </li>
+                <li data-accordion-item class="bx--accordion__item" id="instance-error-row" style="display:none;">
+                    <button class="bx--accordion__heading accordion-title" aria-expanded="false" aria-controls="paneError" onclick=handleInstanceSelection(this)>
+                        <svg focusable="false" preserveAspectRatio="xMidYMid meet" style="will-change: transform;" xmlns="http://www.w3.org/2000/svg" class="bx--accordion__arrow" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+                            <path d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"></path>
+                        </svg>
+                        <div class="bx--accordion__title">No instance found</div>
+                    </button>
+                    <div id="paneError" class="bx--accordion__content hidden" data-hubName="n/a" data-appsodyURL="n/a" data-codewindURL="n/a" data-collections="" data-cliURL="n/a">
+                    </div>
+                </li>
+                <li data-accordion-item class="bx--accordion__item" id="blank-row">
+                    <button class="bx--accordion__heading accordion-title" aria-expanded="false" aria-controls="pane${this.instanceName}" onclick=handleInstanceSelection(this)>
+                      <svg focusable="false" preserveAspectRatio="xMidYMid meet" style="will-change: transform;" xmlns="http://www.w3.org/2000/svg" class="bx--accordion__arrow" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true"><path d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"></path></svg>
+                      <div class="bx--accordion__title"></div>
+                    </button>
+                    <div class="bx--accordion__content">
+                      <p class="gray-text">Date created</p>
+                      <p class="creation-date"></p>
+                    </div>
+                </li>
             </ul>
         </div>
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
This PR refactors how the javascript processes the instance data returned from Kabanero. The implementation of the `updateInstanceView` function read in custom `data-*` attributes that were set for each instance on page load.  This was insufficient for a number of reasons but namely the new collections data that we're adding support for is a JSON object that custom `data-*` attributes are natively only strings.  

In this updated implementation, I've removed the custom `data-*` attributes from each item on the instance accordion.  The return from `fetchAllInstances` (an array with metadata for each instance) is used to populate the instance accordion with the name and creation date of each instance.  Then the instance data from the first instance in the array is passed to `updateInstanceView` which updates the instance and collections cards based on the JSON.  If another instance is selected, the name of that instance is used to parameterize a call to `fetchAnInstance` then the data returned for that single instance is passed into `updateInstanceView`.   

  
