### PR TITLE
Add Eclipse Che to tools and add Che panel on Instance page

### DIFF
--- a/src/main/content/_assets/js/instance.js
+++ b/src/main/content/_assets/js/instance.js
@@ -54,7 +54,6 @@ function loadAllInfo(){
 
 // Set details on UI for any given instance
 function setInstanceData(instances){
-    console.log(instances);
     if(typeof instances === "undefined" || areInstancesEmpty(instances)){
         setErrorHTML();
         return;
@@ -123,6 +122,12 @@ function setToolData(tools){
             $("#pipeline-link").attr("href", tool.location);
             $("#pipeline-button").attr("disabled", false);
             $("#pipeline-button-text").text("Manage Pipelines");
+        }
+
+        if(tool.label === "Eclipse Che"){
+            $("#che-link").attr("href", tool.location);
+            $("#che-button").attr("disabled", false);
+            $("#che-button-text").text("Go to Eclipse Che");
         }
 
         //set kappnav url to manage applications link

--- a/src/main/content/_assets/js/instance.js
+++ b/src/main/content/_assets/js/instance.js
@@ -95,7 +95,6 @@ function setErrorHTML(){
 
 // Set details on UI for any given instance
 function setToolData(tools){
-    console.log(tools);
     let noTools = true;
 
     if(typeof tools === "undefined"){

--- a/src/main/content/_assets/js/instance.js
+++ b/src/main/content/_assets/js/instance.js
@@ -54,6 +54,7 @@ function loadAllInfo(){
 
 // Set details on UI for any given instance
 function setInstanceData(instances){
+    console.log(instances);
     if(typeof instances === "undefined" || areInstancesEmpty(instances)){
         setErrorHTML();
         return;
@@ -95,6 +96,7 @@ function setErrorHTML(){
 
 // Set details on UI for any given instance
 function setToolData(tools){
+    console.log(tools);
     let noTools = true;
 
     if(typeof tools === "undefined"){

--- a/src/main/content/instance.html
+++ b/src/main/content/instance.html
@@ -176,7 +176,7 @@ permalink: /instance/
                 <!-- pipeline details -->
                 <div class="bx--row instance-number-row">
                     <div class="bx--col">
-                        <h4>Pipelines</h4>
+                        <h2>Pipelines</h2>
                     </div>
                 </div>
 
@@ -237,6 +237,53 @@ permalink: /instance/
                         <a id="appnav-link" target="_blank">
                             <button class="bx--btn bx--btn--secondary tile-instance-button" id="manage-apps-button" type="button" disabled>
                                 <span id="manage-apps-button-text">{{t.instance.not-configured}}</span>
+                                <div class="arrow-container">
+                                <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="#f3f3f3" viewBox="0 0 32 32" aria-hidden="true" style="will-change: transform;"><path d="M18 6l-1.4 1.4 7.5 7.6H3v2h21.1l-7.5 7.6L18 26l10-10z"></path></svg>
+                                </div>
+                            </button>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="bx--col-xlg-4 white-background">
+            <div id="pipelines-details-card" class="bx--tile">
+        
+                <!-- loader -->
+                <div data-inline-loading class="bx--inline-loading" role="alert" aria-live="assertive">
+                    <div class="bx--inline-loading__animation">
+                        <div data-inline-loading-spinner class="bx--loading bx--loading--small">
+                        <svg class="bx--loading__svg" viewBox="-75 -75 150 150">
+                            <circle class="bx--loading__background" cx="0" cy="0" r="26.8125" />
+                            <circle class="bx--loading__stroke" cx="0" cy="0" r="26.8125"/>
+                        </svg>
+                        </div>
+                        <svg focusable="false" preserveAspectRatio="xMidYMid meet" style="will-change: transform;" xmlns="http://www.w3.org/2000/svg" class="bx--inline-loading__checkmark-container" hidden="" data-inline-loading-finished="" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true"><path d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"></path><path d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z" data-icon-path="inner-path" opacity="0"></path></svg>
+                        <svg focusable="false" preserveAspectRatio="xMidYMid meet" style="will-change: transform;" xmlns="http://www.w3.org/2000/svg" class="bx--inline-loading--error" hidden="" data-inline-loading-error="" width="20" height="20" viewBox="0 0 32 32" aria-hidden="true"><path d="M2,16H2A14,14,0,1,0,16,2,14,14,0,0,0,2,16Zm23.15,7.75L8.25,6.85a12,12,0,0,1,16.9,16.9ZM8.24,25.16A12,12,0,0,1,6.84,8.27L23.73,25.16a12,12,0,0,1-15.49,0Z"></path></svg>
+                    </div>
+                </div>
+
+                <!-- pipeline details -->
+                <div class="bx--row instance-number-row">
+                    <div class="bx--col">
+                        <h2>Eclipse Che</h2>
+                    </div>
+                </div>
+
+                <div class="bx--row">
+                    <div class="bx--col">
+                        <p>
+                            Eclipse Che makes Kubernetes development accessible for developer teams, providing one-click developer workspaces and eliminating local environment configuration for your entire team.
+                        </p>
+                    </div>
+                </div>
+
+                <div class="bx--row">
+                    <div class="bx--col-sm-2 bx--col-lg-8">
+                        <a id="che-link" target="_blank">
+                            <button class="bx--btn bx--btn--secondary tile-instance-button" id="che-button" type="button" disabled>
+                                <span id="che-button-text">{{t.instance.not-configured}}</span>
                                 <div class="arrow-container">
                                 <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="#f3f3f3" viewBox="0 0 32 32" aria-hidden="true" style="will-change: transform;"><path d="M18 6l-1.4 1.4 7.5 7.6H3v2h21.1l-7.5 7.6L18 26l10-10z"></path></svg>
                                 </div>

--- a/src/main/java/io/kubernetes/KabaneroClient.java
+++ b/src/main/java/io/kubernetes/KabaneroClient.java
@@ -160,10 +160,13 @@ public class KabaneroClient {
             tools.addTool(new KabaneroTool(Constants.KAPPNAV_LABEL, url));
         }
 
-        routes = KabaneroClient.listRoutes(client, "che");
-        System.out.println("!!!!!!!!");
-        System.out.println(routes.toString());
-        System.out.println("!!!!!!!!");
+        routes = KabaneroClient.listRoutes(client, "kabanero");
+        if (routes != null) {
+            String url = KabaneroClient.getLabeledRoute("che", routes);
+            //che only supports http right now so change the url to http from https
+            String httpURL = url.replace("https", "http");
+            tools.addTool(new KabaneroTool(Constants.CHE_LABEL, httpURL));
+        }
     }
 
     private static List<KabaneroCollection> listKabaneroCollections(ApiClient apiClient, String namespace) throws ApiException {

--- a/src/main/java/io/kubernetes/KabaneroClient.java
+++ b/src/main/java/io/kubernetes/KabaneroClient.java
@@ -159,6 +159,11 @@ public class KabaneroClient {
             String url = KabaneroClient.getLabeledRoute("kappnav-ui-service", routes);
             tools.addTool(new KabaneroTool(Constants.KAPPNAV_LABEL, url));
         }
+
+        routes = KabaneroClient.listRoutes(client, "che");
+        System.out.println("!!!!!!!!");
+        System.out.println(routes.toString());
+        System.out.println("!!!!!!!!");
     }
 
     private static List<KabaneroCollection> listKabaneroCollections(ApiClient apiClient, String namespace) throws ApiException {

--- a/src/main/java/io/website/Constants.java
+++ b/src/main/java/io/website/Constants.java
@@ -51,6 +51,9 @@ public final class Constants {
     public static final String KAPPNAV_LABEL = "Application Navigator";
     public static final String KAPPNAV_URL = getEnv("KAPPNAV_URL", "");
 
+    public static final String CHE_LABEL = "Eclipse Che";
+    public static final String CHE_URL = getEnv("CHE_URL", "");
+
 
     // OKD
     public static final String LANDING_URL = getEnv("LANDING_URL", "https://kabanero.io");


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
This PR implements the data for linking to Eclipse Che on the front end (a link on the instance page as pictured below) and on the back end (reading in the Che route from the Kabanero client).

![Screen Shot 2019-12-05 at 3 18 50 PM](https://user-images.githubusercontent.com/37549026/70270743-0b827b80-1773-11ea-8e32-437233942f62.png)
