### PR TITLE
Add right padding to guides section body

### DIFF
--- a/src/main/content/_assets/css/guide.scss
+++ b/src/main/content/_assets/css/guide.scss
@@ -222,7 +222,7 @@ header {
 /* End of pointed div */
 
 #guide-content .sect1 > .sectionbody {
-    padding: 19px 0 0 25px;
+    padding: 19px 25px 0 25px;
     margin-bottom: 100px;
 }
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
This PR adds equal padding to the right of the section body of guides as is on the left side.