### PR TITLE
fixing link to config oauth doc in collections tile

### DIFF
--- a/src/main/content/_assets/js/docs.js
+++ b/src/main/content/_assets/js/docs.js
@@ -43,7 +43,8 @@ function areLinksVisible(links){
 
 function selectDocInToc(){
     let currentHref = window.location.href;
-    let selectedFile = '/docs/ref/general' + currentHref.substring(currentHref.lastIndexOf('/'));
+    let categorie = location.pathname.split('/')[4];
+    let selectedFile = '/docs/ref/general/' + categorie + currentHref.substring(currentHref.lastIndexOf('/'));
     if(selectedFile !== '/docs/ref/general/docs-welcome.html'){
         $(`a[href$="${selectedFile}"]`).addClass('active-doc')
         $( `a[href$="${selectedFile}"]` ).parent().parent().parent().find('.toc-category').click();

--- a/src/main/content/_assets/js/docs.js
+++ b/src/main/content/_assets/js/docs.js
@@ -43,8 +43,8 @@ function areLinksVisible(links){
 
 function selectDocInToc(){
     let currentHref = window.location.href;
-    let categorie = location.pathname.split('/')[4];
-    let selectedFile = '/docs/ref/general/' + categorie + currentHref.substring(currentHref.lastIndexOf('/'));
+    let category = location.pathname.split('/')[4];
+    let selectedFile = '/docs/ref/general/' + category + currentHref.substring(currentHref.lastIndexOf('/'));
     if(selectedFile !== '/docs/ref/general/docs-welcome.html'){
         $(`a[href$="${selectedFile}"]`).addClass('active-doc')
         $( `a[href$="${selectedFile}"]` ).parent().parent().parent().find('.toc-category').click();

--- a/src/main/content/instance.html
+++ b/src/main/content/instance.html
@@ -124,7 +124,7 @@ permalink: /instance/
                 <!-- Collections bottom button -->
                 <div class="bx--row">
                     <div class="bx--col-sm-2 bx--col-lg-8">
-                        <a id="collections-link" href="{{site.url}}/docs/ref/general/configuration/configure-oauth.html">
+                        <a id="collections-link" href="{{page.url | remove: '/instance'}}docs/ref/general/configuration/configure-oauth.html">
                             <button class="bx--btn bx--btn--secondary tile-instance-button" id="collections-btn" type="button">
                                 <span id="collections-oauth-msg">{{t.instance.oauth.configure}}</span>
                                 <div class="arrow-container">

--- a/src/main/content/instance.html
+++ b/src/main/content/instance.html
@@ -124,7 +124,7 @@ permalink: /instance/
                 <!-- Collections bottom button -->
                 <div class="bx--row">
                     <div class="bx--col-sm-2 bx--col-lg-8">
-                        <a id="collections-link" href="docs/ref/general/configure-oauth.html">
+                        <a id="collections-link" href="{{site.url}}/docs/ref/general/configuration/configure-oauth.html">
                             <button class="bx--btn bx--btn--secondary tile-instance-button" id="collections-btn" type="button">
                                 <span id="collections-oauth-msg">{{t.instance.oauth.configure}}</span>
                                 <div class="arrow-container">


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
fixing configure oauth button link on instance page collections tile
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
