### PR TITLE
add digest policy selection dropdown and multi instance accordion fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,19 @@
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>oss.sonatype.org-snapshot</id>
+            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>javax.ws.rs</groupId>
@@ -70,7 +83,7 @@
         <dependency>
             <groupId>io.kabanero</groupId>
             <artifactId>operator-java-bindings</artifactId>
-            <version>0.6.0</version>
+            <version>0.8.0-SNAPSHOT</version>
         </dependency>
         <!-- BEGIN: Needed to compile and run unit tests -->
         <dependency>

--- a/src/main/content/_assets/css/instance.scss
+++ b/src/main/content/_assets/css/instance.scss
@@ -166,7 +166,7 @@ button:disabled > .arrow-container > svg{
     padding-bottom: 5px;
 }
 
-.instancre-details{
+.instance-details{
     display: flex;
 }
 
@@ -300,7 +300,7 @@ button:disabled > .arrow-container > svg{
     background: #f4f4f4;
 }
 
-.add-user-button-icon{
+.margin-right-icon{
     margin-right: 4px;
 }
 
@@ -315,4 +315,8 @@ button:disabled > .arrow-container > svg{
 
 .green-checkmark-fill {
     fill: $support-02;
+}
+
+.active-instance > button {
+    background-color: $ui-03;
 }

--- a/src/main/content/_assets/css/instance.scss
+++ b/src/main/content/_assets/css/instance.scss
@@ -23,7 +23,8 @@
 "../../../../../node_modules/carbon-components/scss/components/loading/loading",
 "../../../../../node_modules/carbon-components/scss/components/tile/tile",
 "../../../../../node_modules/carbon-components/scss/components/notification/inline-notification",
-"../../../../../node_modules/carbon-components/scss/components/text-input/text-input"; 
+"../../../../../node_modules/carbon-components/scss/components/text-input/text-input",
+"../../../../../node_modules/carbon-components/scss/components/dropdown/dropdown";
 //declare variables
 $color-ibm:#3d70b2;
 $kabanero-color: #C43804;
@@ -309,5 +310,9 @@ button:disabled > .arrow-container > svg{
 
 #num-stacks {
     font-weight: 400;
-    margin-top: 1em;
+    margin-top: .5em;
 } 
+
+.green-checkmark-fill {
+    fill: $support-02;
+}

--- a/src/main/content/_assets/css/stacks.scss
+++ b/src/main/content/_assets/css/stacks.scss
@@ -39,7 +39,46 @@ $kabanero-color: #C43804;
     }
 }
 
-.icon-disabled{
+.icon-disabled {
     fill: grey !important;
     cursor: not-allowed !important;
+}
+
+.digest-error-icon {
+    fill: $danger;
+}
+
+.digest-warn-icon {
+    fill: $support-03
+}
+
+.digest-error {
+    border-left: 5px solid $inverse-support-01;
+}
+
+.digest-warning {
+    border-left: 5px solid $support-03;
+}
+
+.digest-notification {
+
+    a {
+        color: $ui-02;
+        text-decoration: underline !important;
+    }
+
+    td {
+
+        &:hover{
+            color: $ui-02 !important;
+            background-color: $ui-05 !important;
+        }
+
+        color: $ui-02 !important;
+        background-color: $ui-05 !important;
+    }
+}
+
+.digest-notification-x {
+    cursor: pointer;
 }

--- a/src/main/content/_assets/js/instance-common.js
+++ b/src/main/content/_assets/js/instance-common.js
@@ -447,15 +447,14 @@ function setInstanceSelections(selectionName) {
 
             // If selectionName is passed we will set the active tab to one that matches that name, otherwise we set the first one in the list.
             // For the selectionName == true case - we need to find the tab where the child div has the same instance name, but we want to return the "li" parent
-            let $activeInstance = selectionName ? $("#instance-accordion li .bx--accordion__title").filter((_, elem) => $(elem).text() === selectionName).get(0).closest("li") :
+            let $activeInstance = typeof selectionName !== "undefined" ? $("#instance-accordion li .bx--accordion__title").filter((_, elem) => $(elem).text() === selectionName).first().closest("li") :
                 $("#instance-accordion li").first();
             
-            if(selectionName && !$activeInstance){
+            if(selectionName && !$activeInstance){  
                 console.log(`Accordion could not find a selection instance for name: ${selectionName}`);
                 return;
             }
-
-            $activeInstance.addClass("bx--accordion__item--active active-instance");
+            $($activeInstance).addClass("bx--accordion__item--active active-instance");
             return $activeInstance.find(".bx--accordion__title").text().trim();
         });
 }

--- a/src/main/content/_assets/js/instance-common.js
+++ b/src/main/content/_assets/js/instance-common.js
@@ -86,10 +86,9 @@ function fetchUserAdminStatus(oauthJSON) {
 }
 
 
-function fetchInstanceAdmins(isAdmin){
+function fetchInstanceAdmins(adminStatus){
     let instanceName = $("#instance-accordion").find(".bx--accordion__title").text();
-
-    if (typeof instanceName === "undefined" || !isAdmin) {
+    if (typeof instanceName === "undefined" || !adminStatus.isAdmin) {
         return;
     }
     
@@ -158,10 +157,10 @@ function removeTeamMember(target) {
         return;
     }
     return fetch(`/api/auth/git/team/${teamId}/member/${githubUsername}`, {
-        method: 'DELETE'
+        method: "DELETE"
     })
         .then(function (response) {
-            return response.json()
+            return response.json();
         })
         .then(data => {
             if (data.msg.includes("404")) {
@@ -188,6 +187,7 @@ function updateInstanceAdminView(adminMembersJson) {
 
     adminMembersJson.forEach(team => {
         if (team.members.length === 0) {
+            $("#admin-modal-no-admins").show();
             return;
         }
 
@@ -227,8 +227,11 @@ function updateInstanceAdminView(adminMembersJson) {
     uniqueAdminList.forEach(user => {
         let githubAdminUsername = user.login;
         $("#instance-accordion-admins-list").append(`<span class="instance-admin-names">${githubAdminUsername}<span>`);
-        $("#instance-accordion-admin-view").removeClass("hidden");
     });
+    
+    if(uniqueAdminList.length > 0){
+        $("#instance-accordion-admin-view").removeClass("hidden");
+    }
 }
 
 let ToolPane = class {

--- a/src/main/content/_assets/js/instance-common.js
+++ b/src/main/content/_assets/js/instance-common.js
@@ -419,44 +419,46 @@ function getActiveInstanceName(){
 
 // Set each instance name in the accordion selection. 
 // If a selectionName is passed in, the accordion will expand that instance (select) if it matches an instance name.
-function setInstanceSelections(selectionName) {   
+function setAllInstances(selectionName) {   
     return fetchAllInstances()
-        .then(instancesJSON => {
-            let instances = instancesJSON.items;
-            if (typeof instances === "undefined" || instances.length === 0) {
-                $("#instance-accordion #error-li").show();
+        .then((allInst) => setInstancesSelections(allInst, selectionName));
+}
 
-                $(".bx--inline-loading").hide();
-                console.error("No Kabanero instances were returned");
-                return;
-            }
+function setInstancesSelections(instancesJSON, selectionName){
+    let instances = instancesJSON.items;
+    if (typeof instances === "undefined" || instances.length === 0) {
+        $("#instance-accordion #error-li").show();
 
-            $("#instance-accordion").empty();
+        $(".bx--inline-loading").hide();
+        console.error("No Kabanero instances were returned");
+        return;
+    }
 
-            for (let instance of instances) {
-                let dateCreated = instance.metadata.creationTimestamp;
+    $("#instance-accordion").empty();
 
-                let row = $("#instance-li-template").clone().removeAttr("id").removeClass("hidden");
-                $(row).find(".bx--accordion__title").text(instance.metadata.name);
-                $(row).find(".creation-date").text(new Date(dateCreated).toLocaleDateString());
-                $("#instance-accordion").append(row);
-            }
+    for (let instance of instances) {
+        let dateCreated = instance.metadata.creationTimestamp;
 
-            // Remove the error li from the carbon accordion. Carbon needs at least 1 li element there on load or it throws an error...
-            $("#instance-accordion #error-li").remove();
+        let row = $("#instance-li-template").clone().removeAttr("id").removeClass("hidden");
+        $(row).find(".bx--accordion__title").text(instance.metadata.name);
+        $(row).find(".creation-date").text(new Date(dateCreated).toLocaleDateString());
+        $("#instance-accordion").append(row);
+    }
 
-            // If selectionName is passed we will set the active tab to one that matches that name, otherwise we set the first one in the list.
-            // For the selectionName == true case - we need to find the tab where the child div has the same instance name, but we want to return the "li" parent
-            let $activeInstance = typeof selectionName !== "undefined" ? $("#instance-accordion li .bx--accordion__title").filter((_, elem) => $(elem).text() === selectionName).first().closest("li") :
-                $("#instance-accordion li").first();
-            
-            if(selectionName && !$activeInstance){  
-                console.log(`Accordion could not find a selection instance for name: ${selectionName}`);
-                return;
-            }
-            $($activeInstance).addClass("bx--accordion__item--active active-instance");
-            return $activeInstance.find(".bx--accordion__title").text().trim();
-        });
+    // Remove the error li from the carbon accordion. Carbon needs at least 1 li element there on load or it throws an error...
+    $("#instance-accordion #error-li").remove();
+
+    // If selectionName is passed we will set the active tab to one that matches that name, otherwise we set the first one in the list.
+    // For the selectionName == true case - we need to find the tab where the child div has the same instance name, but we want to return the "li" parent
+    let $activeInstance = typeof selectionName !== "undefined" ? $("#instance-accordion li .bx--accordion__title").filter((_, elem) => $(elem).text() === selectionName).first().closest("li") :
+        $("#instance-accordion li").first();
+    
+    if(selectionName && !$activeInstance){  
+        console.log(`Accordion could not find a selection instance for name: ${selectionName}`);
+        return;
+    }
+    $($activeInstance).addClass("bx--accordion__item--active active-instance");
+    return $activeInstance.find(".bx--accordion__title").text().trim();
 }
 
 // Change the accordion when a new instance is clicked and return the new selected instance name

--- a/src/main/content/_assets/js/instance-common.js
+++ b/src/main/content/_assets/js/instance-common.js
@@ -489,3 +489,9 @@ function setDigestGovernanacePolicy(){
         .then(() => $("#digest-checkmark").fadeIn("slow").delay(5000).fadeOut("slow"))
         .catch(error => console.error(`Error setting new digest policy to: ${policy}`, error));
 }
+
+function createSVG(id, classNames, width, height, fill){
+    return `<svg class="${classNames}" width="${width}" height="${height}" fill="${fill}">
+        <use xlink:href="/img/carbon-icons/carbon-icons.svg#icon--${id}"></use>
+    </svg>`;
+}

--- a/src/main/content/_assets/js/instance.js
+++ b/src/main/content/_assets/js/instance.js
@@ -18,7 +18,7 @@
 
 $(document).ready(function () {
     
-    setInstanceSelections()
+    setAllInstances()
         .then(fetchAnInstance)
         .then(loadAllInfo);
 
@@ -58,7 +58,6 @@ function setListeners() {
     }
 }
 
-// Request to get all instances names
 function loadAllInfo(instanceJSON) {
     if (typeof instanceJSON === "undefined") {
         console.log("instance data is undefined, cannot load instance");

--- a/src/main/content/_assets/js/instance.js
+++ b/src/main/content/_assets/js/instance.js
@@ -76,24 +76,6 @@ function loadAllInfo(instanceJSON) {
         .then(fetchUserAdminStatus);
 }
 
-function displayDigest(instance){
-    if(!instance.spec || !instance.spec.governancePolicy){
-        console.log("Failed to get stack govern policy. instance.spec or instance.spec.governancePoliy does not exist.");
-        return;
-    }
-    // The way carbon dropdown works is different than normal select. 
-    // This gets the current li that the server says is the current digest, and sets the display to that text.
-    // Then it adds the selected class since it doesn't make sense to select the same li that is already the current digest.
-    let policy = instance.spec.governancePolicy.stackPolicy;
-
-    $("#stack-govern-dropdown li").show();
-    let $currentPolicyLi = $(`#stack-govern-dropdown li[data-value='${policy}']`);
-    let translatedPolicyText = $currentPolicyLi.find("a").first().text();
-    $("#stack-govern-value").attr("data-value", policy);
-    $("#stack-govern-value-text").text(translatedPolicyText);
-    $currentPolicyLi.addClass("bx--dropdown--selected");
-}
-
 // Set details on UI for any given instance
 function setToolData(tools) {
     let noTools = true;

--- a/src/main/content/_assets/js/stacks.js
+++ b/src/main/content/_assets/js/stacks.js
@@ -1,17 +1,14 @@
 $(document).ready(function () {
-    handleInstancesRequests();
-    $("#instance-accordion li").on("click", e => {
-        // prevent carbon from doing its normal thing with the accordion
-        e.stopPropagation();
+    let url = new URL(location.href);
+    let instanceName = url.searchParams.get("name");
 
-        let newName = handleInstanceSelection(e.target);
-        fetchAnInstance(newName)
-            .then(updateInstanceView);
-    });
+    setInstanceSelections(instanceName);
+    fetchAnInstance(instanceName)
+        .then(loadAllInfo);
 
     $("#sync-stacks-icon").on("click", (e) => {
         if (e.target.getAttribute("class") == "icon-active") {
-            let instanceName = $("#instance-accordion").find(".bx--accordion__title").text();
+            let instanceName = getActiveInstanceName();
             emptyTable();
             syncStacks(instanceName);
         }
@@ -34,13 +31,9 @@ $(document).ready(function () {
     
 });
 
-function handleInstancesRequests() {
-    $("#instance-accordion").empty();
-    fetchAllInstances()
-        .then(setInstanceSelections)
-        .then(handleInitialCLIAuth)
+function loadAllInfo(instanceName){
+    handleInitialCLIAuth(instanceName)
         .then(handleStacksRequests);
-    //TODO select/fetch current instance from url param for the dropdown
 }
 
 function handleStacksRequests(instanceName) {
@@ -73,7 +66,7 @@ function getCliVersion(instanceName) {
 }
 
 function deactivateStack(name, version) {
-    let instanceName = $("#instance-accordion").find(".bx--accordion__title").text();
+    let instanceName = getActiveInstanceName();
 
     return fetch(`/api/auth/kabanero/${instanceName}/stacks/${name}/versions/${version}`, { method: "DELETE" })
         .then(function (response) {

--- a/src/main/content/_assets/js/stacks.js
+++ b/src/main/content/_assets/js/stacks.js
@@ -8,7 +8,7 @@ $(document).ready(function () {
     let url = new URL(location.href);
     let instanceName = url.searchParams.get("name");
 
-    setInstanceSelections(instanceName);
+    setAllInstances(instanceName);
     fetchAnInstance(instanceName)
         .then(loadAllInfo);
 

--- a/src/main/content/_data/en/en.yml
+++ b/src/main/content/_data/en/en.yml
@@ -4,6 +4,7 @@ common:
   codewind: Codewind
   eclipse: Eclipse
   vscode: VS Code
+  loading: loading
 _includes:
   header:
     whats-new-toast-text: Check out what's in the latest release of Kabanero
@@ -125,6 +126,12 @@ instance:
   instances: Instances
   copied: copied!
   stacks: Stacks
+  stack-govern: 
+    policy: Stack Governance Policy
+    strictDigest: Strict Digest
+    activeDigest: Active Digest
+    ignoreDigest: Ignore Digest
+    noDigest: None
   curated-stacks: Curated Stacks
   instance-details: Instance details
   kab-instances: Kabanero Instances
@@ -153,6 +160,7 @@ instance:
   date-created: "Date created: "
   members: "Members: "
   admins: Admins
+  no-admins: No Admins
   username: Username
   user: User
   full-name: Full Name
@@ -169,8 +177,8 @@ instance:
   modal-deactivate-button: Deactivate
   modal-done-button: Done
   management-cli: Stack Hub Management CLI
-  management-cli-pre: Use this endpoint with the Kabanero Management CLI login command to login and manage your stacks. For more information about using the CLI see the
-  management-cli-post: Kabanero Management CLI documentation
+  management-cli-pre: Use this endpoint with the Stack Management CLI login command to manage your stacks. For more information see the
+  management-cli-post: Stack Management CLI documentation
   codeready: Red Hat CodeReady Workspaces
   codeready-blurb: Red Hat CodeReady Workspaces provides a consistent, secure, and zero-configuration development environment.
 

--- a/src/main/content/img/deactivateStack.svg
+++ b/src/main/content/img/deactivateStack.svg
@@ -1,0 +1,4 @@
+<svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 32 32" aria-hidden="true" style="will-change: transform;">
+    <path d="M16,4A12,12,0,1,1,4,16,12,12,0,0,1,16,4m0-2A14,14,0,1,0,30,16,14,14,0,0,0,16,2Z"></path>
+    <path d="M10 15H22V17H10z"></path>
+</svg>

--- a/src/main/content/instance.html
+++ b/src/main/content/instance.html
@@ -253,7 +253,7 @@ permalink: /instance/
                             <input type="text" class="bx--text-input add-user-text-input"
                                 placeholder="{{t.instance.username}}">
                             <div class="input-error-msg-icon hidden">
-                                <img class="" src="/img/invalid_warning.svg">
+                                <img src="/img/invalid_warning.svg">
                             </div>
                         </div>
                         <div class="bx--form-requirement input-error-message"></div>

--- a/src/main/content/instance.html
+++ b/src/main/content/instance.html
@@ -19,6 +19,7 @@ permalink: /instance/
         </div>
     </div>
 
+    <!-- Instance Accordion -->
     <div class="bx--row">
         <div class="bx--col-xlg-4">
             <div class="bx--row">
@@ -104,66 +105,6 @@ permalink: /instance/
                             </div>
                         </div>
 
-                        <!-- stack governance -->
-                        <div class="bx--row">
-                            <div class="bx--col">
-                                <div class="bx--form-item">
-                                    <div id="stack-govern-dropdown" class="bx--dropdown__wrapper">
-                                        <span id="stack-govern-label" class="bx--label">{{t.instance.stack-govern.policy}}</span>
-                                        <div id="stack-govern-value" data-dropdown data-value class="bx--dropdown">
-                                            <button class="bx--dropdown-text" aria-haspopup="true" aria-expanded="false"
-                                                aria-controls="stack-govern-menu"
-                                                aria-labelledby="stack-govern-label stack-govern-value-text"
-                                                type="button">
-                                                <span class="bx--dropdown-text__inner" id="stack-govern-value-text">
-                                                    {{t.common.loading}}
-                                                </span>
-                                                <span class="bx--dropdown__arrow-container">
-                                                    <svg focusable="false" preserveAspectRatio="xMidYMid meet"
-                                                        style="will-change: transform;"
-                                                        xmlns="http://www.w3.org/2000/svg" class="bx--dropdown__arrow"
-                                                        width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
-                                                        <path d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"></path>
-                                                    </svg>
-                                                </span>
-                                                <svg id="digest-checkmark" class="green-checkmark-fill hide" width="13" height="13">
-                                                    <use xlink:href="/img/carbon-icons/carbon-icons.svg#icon--checkmark"></use>
-                                                </svg>
-                                            </button>
-                                            <ul class="bx--dropdown-list" role="menu" tabindex="0"
-                                                id="stack-govern-menu" aria-hidden="true" wh-menu-anchor="left"
-                                                aria-labelledby="stack-govern-label">
-                                                <li data-option data-value="strictDigest" class="bx--dropdown-item"
-                                                    title="{{t.instance.stack-govern.strictDigest}}">
-                                                    <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1"
-                                                        role="menuitemradio" aria-checked="true"
-                                                        id="stack-govern-item0">{{t.instance.stack-govern.strictDigest}}</a>
-                                                </li>
-                                                <li data-option data-value="activeDigest" class="bx--dropdown-item"
-                                                    title="{{t.instance.stack-govern.activeDigest}}">
-                                                    <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1"
-                                                        role="menuitemradio" aria-checked="false"
-                                                        id="stack-govern-item1">{{t.instance.stack-govern.activeDigest}}</a>
-                                                </li>
-                                                <li data-option data-value="ignoreDigest" class="bx--dropdown-item"
-                                                    title="{{t.instance.stack-govern.ignoreDigest}}">
-                                                    <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1"
-                                                        role="menuitemradio" aria-checked="false"
-                                                        id="stack-govern-item2">{{t.instance.stack-govern.ignoreDigest}}</a>
-                                                </li>
-                                                <li data-option data-value="none" class="bx--dropdown-item"
-                                                    title="{{t.instance.stack-govern.none}}">
-                                                    <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1"
-                                                        role="menuitemradio" aria-checked="false"
-                                                        id="stack-govern-item3">{{t.instance.stack-govern.noDigest}}</a>
-                                                </li>
-                                            </ul>
-                                        </div>
-                                    </div>
-                                </div>                        
-                            </div>
-                        </div>
-
                         <div class="bx--row">
                             <div id="stack-list" class="bx--col"></div>
                         </div>
@@ -228,8 +169,7 @@ permalink: /instance/
 
 <!-- Templates -->
 <li id="instance-li-template" data-accordion-item class="bx--accordion__item hidden">
-    <button class="bx--accordion__heading accordion-title" aria-expanded="false"
-        aria-controls="pane${this.instanceName}">
+    <button class="bx--accordion__heading accordion-title" aria-expanded="false" aria-controls="pane">
         <svg focusable="false" preserveAspectRatio="xMidYMid meet" style="will-change: transform;"
             xmlns="http://www.w3.org/2000/svg" class="bx--accordion__arrow" width="16" height="16" viewBox="0 0 16 16"
             aria-hidden="true">
@@ -239,7 +179,7 @@ permalink: /instance/
     </button>
     <div class="bx--accordion__content">
         <p>{{t.instance.details}}</p>
-        <div class="instancre-details">
+        <div class="instance-details">
             <p class="gray-text">{{t.instance.date-created}}</p>
             <p class="creation-date"></p>
         </div>
@@ -320,7 +260,7 @@ permalink: /instance/
                     </div>
 
                     <button class="bx--btn bx--btn--secondary bx--btn--field add-user-button" type="button">
-                        <svg class="add-user-button-icon" width="13" height="13" fill="#ffffff">
+                        <svg class="margin-right-icon" width="13" height="13" fill="#ffffff">
                             <use xlink:href="/img/carbon-icons/carbon-icons.svg#icon--add"></use>
                         </svg>
 

--- a/src/main/content/instance.html
+++ b/src/main/content/instance.html
@@ -104,6 +104,66 @@ permalink: /instance/
                             </div>
                         </div>
 
+                        <!-- stack governance -->
+                        <div class="bx--row">
+                            <div class="bx--col">
+                                <div class="bx--form-item">
+                                    <div id="stack-govern-dropdown" class="bx--dropdown__wrapper">
+                                        <span id="stack-govern-label" class="bx--label">{{t.instance.stack-govern.policy}}</span>
+                                        <div id="stack-govern-value" data-dropdown data-value class="bx--dropdown">
+                                            <button class="bx--dropdown-text" aria-haspopup="true" aria-expanded="false"
+                                                aria-controls="stack-govern-menu"
+                                                aria-labelledby="stack-govern-label stack-govern-value-text"
+                                                type="button">
+                                                <span class="bx--dropdown-text__inner" id="stack-govern-value-text">
+                                                    {{t.common.loading}}
+                                                </span>
+                                                <span class="bx--dropdown__arrow-container">
+                                                    <svg focusable="false" preserveAspectRatio="xMidYMid meet"
+                                                        style="will-change: transform;"
+                                                        xmlns="http://www.w3.org/2000/svg" class="bx--dropdown__arrow"
+                                                        width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+                                                        <path d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"></path>
+                                                    </svg>
+                                                </span>
+                                                <svg id="digest-checkmark" class="green-checkmark-fill hide" width="13" height="13">
+                                                    <use xlink:href="/img/carbon-icons/carbon-icons.svg#icon--checkmark"></use>
+                                                </svg>
+                                            </button>
+                                            <ul class="bx--dropdown-list" role="menu" tabindex="0"
+                                                id="stack-govern-menu" aria-hidden="true" wh-menu-anchor="left"
+                                                aria-labelledby="stack-govern-label">
+                                                <li data-option data-value="strictDigest" class="bx--dropdown-item"
+                                                    title="{{t.instance.stack-govern.strictDigest}}">
+                                                    <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1"
+                                                        role="menuitemradio" aria-checked="true"
+                                                        id="stack-govern-item0">{{t.instance.stack-govern.strictDigest}}</a>
+                                                </li>
+                                                <li data-option data-value="activeDigest" class="bx--dropdown-item"
+                                                    title="{{t.instance.stack-govern.activeDigest}}">
+                                                    <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1"
+                                                        role="menuitemradio" aria-checked="false"
+                                                        id="stack-govern-item1">{{t.instance.stack-govern.activeDigest}}</a>
+                                                </li>
+                                                <li data-option data-value="ignoreDigest" class="bx--dropdown-item"
+                                                    title="{{t.instance.stack-govern.ignoreDigest}}">
+                                                    <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1"
+                                                        role="menuitemradio" aria-checked="false"
+                                                        id="stack-govern-item2">{{t.instance.stack-govern.ignoreDigest}}</a>
+                                                </li>
+                                                <li data-option data-value="none" class="bx--dropdown-item"
+                                                    title="{{t.instance.stack-govern.none}}">
+                                                    <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1"
+                                                        role="menuitemradio" aria-checked="false"
+                                                        id="stack-govern-item3">{{t.instance.stack-govern.noDigest}}</a>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>                        
+                            </div>
+                        </div>
+
                         <div class="bx--row">
                             <div id="stack-list" class="bx--col"></div>
                         </div>
@@ -189,7 +249,6 @@ permalink: /instance/
             <div>
                 <div id="instance-accordion-admins-list"></div>
                 <a id="manage-admins-link" data-modal-target="#manage-admins-modal">{{t.instance.manage-admins}}</a>
-
             </div>
         </div>
     </div>
@@ -290,7 +349,19 @@ permalink: /instance/
             </button>
         </div>
         <div id="admin-modal-content" class="bx--modal-content">
-            <ul data-accordion class="bx--accordion" id="admin-modal-list"></ul>
+            <ul id="admin-modal-list" data-accordion>
+                <li id="admin-modal-no-admins" data-accordion-item class="bx--accordion__item hide">
+                    <button class="bx--accordion__heading accordion-title" aria-expanded="false"
+                        aria-controls="paneError">
+                        <svg focusable="false" preserveAspectRatio="xMidYMid meet" style="will-change: transform;"
+                            xmlns="http://www.w3.org/2000/svg" class="bx--accordion__arrow" width="16" height="16"
+                            viewBox="0 0 16 16" aria-hidden="true">
+                            <path d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"></path>
+                        </svg>
+                        <div class="bx--accordion__title">{{t.instance.no-admins}}</div>
+                    </button>
+                </li>
+            </ul>
         </div>
         <div class="bx--modal-content--overflow-indicator"></div>
         <div class="bx--modal-footer">

--- a/src/main/content/stacks.html
+++ b/src/main/content/stacks.html
@@ -20,13 +20,30 @@ permalink: /instance/stacks/
         </div>
     </div>
 
+    <!-- Instance Accordion -->
     <div class="bx--row">
         <div class="bx--col-xlg-4">
-            <ul data-accordion class="bx--accordion" id="instance-accordion">
-                <li>
-                    <button></button>
-                </li>
-            </ul>
+            <div class="bx--row">
+                <div class="bx--col">
+                    <ul data-accordion class="bx--accordion" id="instance-accordion">
+                        <li id="error-li" data-accordion-item class="bx--accordion__item hide">
+                            <button class="bx--accordion__heading accordion-title" aria-expanded="false"
+                                aria-controls="paneError">
+                                <svg focusable="false" preserveAspectRatio="xMidYMid meet"
+                                    style="will-change: transform;" xmlns="http://www.w3.org/2000/svg"
+                                    class="bx--accordion__arrow" width="16" height="16" viewBox="0 0 16 16"
+                                    aria-hidden="true">
+                                    <path d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"></path>
+                                </svg>
+                                <div class="bx--accordion__title">{{t.instance.no-instances}}</div>
+                            </button>
+                            <div id="paneError" class="bx--accordion__content hidden" data-hubName="n/a"
+                                data-appsodyURL="n/a" data-codewindURL="n/a" data-stacks="" data-cliURL="n/a">
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+            </div>
         </div>
 
         <!-- Kabanero Stacks table -->
@@ -34,16 +51,73 @@ permalink: /instance/stacks/
             <div class="bx--row">
                 <div class="bx--col-xlg">
                     <div id="stack-table-container">
+                        <!-- stack governance -->
+                        <div class="bx--row">
+                            <div class="bx--col">
+                                <div class="bx--form-item">
+                                    <div id="stack-govern-dropdown" class="bx--dropdown__wrapper">
+                                        <span id="stack-govern-label" class="bx--label">{{t.instance.stack-govern.policy}}</span>
+                                        <div id="stack-govern-value" data-dropdown data-value class="bx--dropdown">
+                                            <button class="bx--dropdown-text" aria-haspopup="true" aria-expanded="false"
+                                                aria-controls="stack-govern-menu"
+                                                aria-labelledby="stack-govern-label stack-govern-value-text"
+                                                type="button">
+                                                <span class="bx--dropdown-text__inner" id="stack-govern-value-text">
+                                                    {{t.common.loading}}
+                                                </span>
+                                                <span class="bx--dropdown__arrow-container">
+                                                    <svg focusable="false" preserveAspectRatio="xMidYMid meet"
+                                                        style="will-change: transform;"
+                                                        xmlns="http://www.w3.org/2000/svg" class="bx--dropdown__arrow"
+                                                        width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+                                                        <path d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"></path>
+                                                    </svg>
+                                                </span>
+                                                <svg id="digest-checkmark" class="green-checkmark-fill hide" width="13" height="13">
+                                                    <use xlink:href="/img/carbon-icons/carbon-icons.svg#icon--checkmark"></use>
+                                                </svg>
+                                            </button>
+                                            <ul class="bx--dropdown-list" role="menu" tabindex="0"
+                                                id="stack-govern-menu" aria-hidden="true" wh-menu-anchor="left"
+                                                aria-labelledby="stack-govern-label">
+                                                <li data-option data-value="strictDigest" class="bx--dropdown-item"
+                                                    title="{{t.instance.stack-govern.strictDigest}}">
+                                                    <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1"
+                                                        role="menuitemradio" aria-checked="true"
+                                                        id="stack-govern-item0">{{t.instance.stack-govern.strictDigest}}</a>
+                                                </li>
+                                                <li data-option data-value="activeDigest" class="bx--dropdown-item"
+                                                    title="{{t.instance.stack-govern.activeDigest}}">
+                                                    <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1"
+                                                        role="menuitemradio" aria-checked="false"
+                                                        id="stack-govern-item1">{{t.instance.stack-govern.activeDigest}}</a>
+                                                </li>
+                                                <li data-option data-value="ignoreDigest" class="bx--dropdown-item"
+                                                    title="{{t.instance.stack-govern.ignoreDigest}}">
+                                                    <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1"
+                                                        role="menuitemradio" aria-checked="false"
+                                                        id="stack-govern-item2">{{t.instance.stack-govern.ignoreDigest}}</a>
+                                                </li>
+                                                <li data-option data-value="none" class="bx--dropdown-item"
+                                                    title="{{t.instance.stack-govern.none}}">
+                                                    <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1"
+                                                        role="menuitemradio" aria-checked="false"
+                                                        id="stack-govern-item3">{{t.instance.stack-govern.noDigest}}</a>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>                        
+                            </div>
+                        </div>
+
+                        <!-- Sync stack refresh icon -->
                         <div class="sync-stacks-button">
                             <button
                                 class="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--left bx--tooltip--align-start">
                                 <span class="bx--assistive-text">{{t.instance.sync-tooltip}}</span>
-                                <svg id="sync-stacks-icon" class="icon-active" focusable="false"
-                                    preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" width="20"
-                                    height="20" viewBox="0 0 32 32" aria-hidden="true" style="will-change: transform;">
-                                    <path
-                                        d="M12 10H6.78A11 11 0 0 1 27 16h2A13 13 0 0 0 6 7.68V4H4v8h8zM20 22h5.22A11 11 0 0 1 5 16H3a13 13 0 0 0 23 8.32V28h2V20H20z">
-                                    </path>
+                                <svg class="margin-right-icon" width="30" height="30" fill="#ffffff">
+                                    <use xlink:href="/img/carbon-icons/carbon-icons.svg#icon--schematics"></use>
                                 </svg>
                             </button>
                         </div>

--- a/src/main/content/stacks.html
+++ b/src/main/content/stacks.html
@@ -51,7 +51,19 @@ permalink: /instance/stacks/
             <div class="bx--row">
                 <div class="bx--col-xlg">
                     <div id="stack-table-container">
-                        <!-- stack governance -->
+                        <!-- Sync stack refresh icon -->
+                        <div class="sync-stacks-button">
+                            <button
+                                class="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--left bx--tooltip--align-start">
+                                <span class="bx--assistive-text">{{t.instance.sync-tooltip}}</span>
+                                <svg class="margin-right-icon" width="30" height="30" fill="#ffffff">
+                                    <use xlink:href="/img/carbon-icons/carbon-icons.svg#icon--schematics"></use>
+                                </svg>
+                            </button>
+                        </div>
+                        <h2>{{t.instance.stacks}}</h2>
+
+                        <!-- stack governance selection -->
                         <div class="bx--row">
                             <div class="bx--col">
                                 <div class="bx--form-item">
@@ -110,18 +122,6 @@ permalink: /instance/stacks/
                                 </div>                        
                             </div>
                         </div>
-
-                        <!-- Sync stack refresh icon -->
-                        <div class="sync-stacks-button">
-                            <button
-                                class="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--left bx--tooltip--align-start">
-                                <span class="bx--assistive-text">{{t.instance.sync-tooltip}}</span>
-                                <svg class="margin-right-icon" width="30" height="30" fill="#ffffff">
-                                    <use xlink:href="/img/carbon-icons/carbon-icons.svg#icon--schematics"></use>
-                                </svg>
-                            </button>
-                        </div>
-                        <h2>{{t.instance.stacks}}</h2>
                         {% include table-loader.html %}
                         <table id="stack-table" class="bx--data-table hide">
                             <thead>

--- a/src/main/java/io/kabanero/api/restricted/StacksEndpoints.java
+++ b/src/main/java/io/kabanero/api/restricted/StacksEndpoints.java
@@ -111,7 +111,7 @@ public class StacksEndpoints extends Application {
             EntityUtils.consume(entity2);
             return Response.ok().entity(body).build();
         } catch (JsonParseException e) {
-            LOGGER.log(Level.SEVERE, "Failed parsing Collections JSON returned from cli server", e);
+            LOGGER.log(Level.SEVERE, "Failed parsing stacks JSON returned from cli server", e);
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
         } finally {
             response.close();
@@ -154,7 +154,7 @@ public class StacksEndpoints extends Application {
     @DELETE
     @Path("/{stack}/versions/{version}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response deactivateCollection(@CookieParam(JWT_COOKIE_KEY) String jwt, @PathParam("stack") final String stackName, @PathParam("version") final String stackVersion) throws ClientProtocolException, IOException, ApiException, GeneralSecurityException {
+    public Response deactivateStack(@CookieParam(JWT_COOKIE_KEY) String jwt, @PathParam("stack") final String stackName, @PathParam("version") final String stackVersion) throws ClientProtocolException, IOException, ApiException, GeneralSecurityException {
         CloseableHttpClient client = createHttpClient();
 
         String cliServerURL = CLI_URL == null ? setCLIURL(INSTANCE_NAME) : CLI_URL;
@@ -187,7 +187,7 @@ public class StacksEndpoints extends Application {
     @PUT
     @Path("/sync")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response syncCollections(@CookieParam(JWT_COOKIE_KEY) String jwt) throws ClientProtocolException, IOException, ApiException, GeneralSecurityException {
+    public Response syncStacks(@CookieParam(JWT_COOKIE_KEY) String jwt) throws ClientProtocolException, IOException, ApiException, GeneralSecurityException {
         CloseableHttpClient client = createHttpClient();
 
         String cliServerURL = CLI_URL == null ? setCLIURL(INSTANCE_NAME) : CLI_URL;
@@ -223,6 +223,11 @@ public class StacksEndpoints extends Application {
     public Response login(@Context HttpServletRequest httpServletRequest) throws ClientProtocolException, IOException, ApiException, GeneralSecurityException {
         String user = httpServletRequest.getUserPrincipal().getName();
         UserProfile userProfile = UserProfileManager.getUserProfile();
+        
+        if(userProfile == null){
+            return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
+
         String token = userProfile.getAccessToken();
 
         String jwt = getJWTFromLogin(user, token, INSTANCE_NAME);

--- a/src/main/java/io/kabanero/digest/DigestPolicy.java
+++ b/src/main/java/io/kabanero/digest/DigestPolicy.java
@@ -1,0 +1,42 @@
+
+/******************************************************************************
+ *
+ * Copyright 2019 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.kabanero.digest;
+
+public class DigestPolicy {
+    public Policy policy;
+
+    public enum Policy {
+        strictDigest, activeDigest, ignoreDigest, none
+    }
+
+    public Policy getPolicy() {
+        return policy;
+    }
+
+    public void setPolicy(Policy policy) {
+        this.policy = policy;
+    }
+
+    @Override
+    public String toString() {
+        return "DigestPolicy [policy=" + policy + "]";
+    }
+
+}

--- a/src/main/java/io/kubernetes/KabaneroClient.java
+++ b/src/main/java/io/kubernetes/KabaneroClient.java
@@ -130,13 +130,26 @@ public class KabaneroClient {
         }
     }
 
+    public static Kabanero updateInstance(Kabanero instance) throws IOException, ApiException, GeneralSecurityException {
+        ApiClient client = KabaneroClient.getApiClient();
+        String instanceName = instance.getMetadata().getName();
+        try{
+            KabaneroApi api = new KabaneroApi(client);
+            return api.updateKabanero(DEFAULT_NAMESPACE, instanceName, instance);
+        }catch (Exception e){
+            LOGGER.log(Level.WARNING, "Error with setting kabanero instance " + instanceName, e);
+            return null;
+        }
+    }
+
     public static StackList getStacks(String instanceName) throws IOException, GeneralSecurityException {
         ApiClient client = KabaneroClient.getApiClient();
         try{
             StackApi api = new StackApi(client);
             return api.listStacks(DEFAULT_NAMESPACE, null, null, TIMEOUT);
-        }catch(Exception e){
-            LOGGER.log(Level.WARNING, "Error with fetching collections in kabanero instance " + instanceName, e);
+        }
+        catch(Exception e){
+            LOGGER.log(Level.WARNING, "Error with fetching stacks in kabanero instance " + instanceName, e);
             return null;
         }
     }

--- a/src/test/java/instance/InstanceIT.java
+++ b/src/test/java/instance/InstanceIT.java
@@ -43,7 +43,7 @@ public class InstanceIT {
         String toolsJSON = new String(Files.readAllBytes(Paths.get("src", "test", "resources", "tools.json")), StandardCharsets.UTF_8);
 
         // execute javascript functions to set mock data
-        js.executeScript("setInstanceSelections(JSON.parse(arguments[0]));", multiInstanceJSON);
+        js.executeScript("setInstancesSelections(JSON.parse(arguments[0]), '');", multiInstanceJSON);
         js.executeScript("setInstanceCard(JSON.parse(arguments[0]));", singleInstanceJSON);
         js.executeScript("setStackCard(JSON.parse(arguments[0]));", stacksJSON);
         js.executeScript("setToolData(JSON.parse(arguments[0]));", toolsJSON);
@@ -66,6 +66,7 @@ public class InstanceIT {
     @Test
     public void displaysCorrectInstanceNameIT() throws InterruptedException {
         String expectedInstanceName = "kabanero";
+
         String actualInstanceName = driver.findElement(By.id("instance-accordion"))
                 .findElement(By.className("bx--accordion__title")).getText();
 

--- a/src/test/java/stacks/StacksIT.java
+++ b/src/test/java/stacks/StacksIT.java
@@ -36,11 +36,11 @@ public class StacksIT {
         driver.get(baseUrl);
 
         js = (JavascriptExecutor) driver;
-
+        String singleInstanceJSON = new String(Files.readAllBytes(Paths.get("src", "test", "resources", "singleInstance.json")), StandardCharsets.UTF_8);
         String stacksJSON = new String(Files.readAllBytes(Paths.get("src", "test", "resources", "stacks.json")), StandardCharsets.UTF_8);
 
         // execute javascript functions to set mock data
-        js.executeScript("updateStackView(JSON.parse(arguments[0]));", stacksJSON);
+        js.executeScript("updateStackView(JSON.parse(arguments[0]), JSON.parse(arguments[1]));", singleInstanceJSON, stacksJSON);
     }
 
     @AfterClass

--- a/src/test/resources/multipleInstances.json
+++ b/src/test/resources/multipleInstances.json
@@ -27,6 +27,9 @@
                 "uid": "3c9c5898-5352-11ea-b0e7-00000a101618"
             },
             "spec": {
+                "governancePolicy": {
+                    "stackPolicy": "activeDigest"
+                },
                 "admissionControllerWebhook": {
                     "image": null,
                     "repository": null,
@@ -219,6 +222,9 @@
                 "uid": "3c9c5898-5352-11ea-b0e7-00000a101618"
             },
             "spec": {
+                "governancePolicy": {
+                    "stackPolicy": "activeDigest"
+                },
                 "admissionControllerWebhook": {
                     "image": null,
                     "repository": null,

--- a/src/test/resources/singleInstance.json
+++ b/src/test/resources/singleInstance.json
@@ -24,6 +24,9 @@
         "uid": "3c9c5898-5352-11ea-b0e7-00000a101618"
     },
     "spec": {
+        "governancePolicy": {
+            "stackPolicy": "activeDigest"
+        },
         "admissionControllerWebhook": {
             "image": null,
             "repository": null,


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

part of #179 This part lets users change their digest policy via a dropdown

this issue also fixes some bugs in the instance accordion when there are multiple kabanero instances (its not supported yet, but this will help when its supported in the future)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
