### PR TITLE
Use new keystore with service gen cert/key.

### DIFF
--- a/src/main/wlp/server.xml
+++ b/src/main/wlp/server.xml
@@ -26,8 +26,11 @@
         <feature>transportSecurity-1.0</feature>
     </featureManager>
     
-    <keyStore id="defaultKeyStore" password="changeit" />
-    <ssl id="defaultSSLConfig" trustDefaultCerts="true" sslProtocol="TLSv1.2"/>
+    <keyStore id="defaultKeyStore" 
+              password="changeit" 
+              location="/etc/tls/secrets/java.io/landingpage/keystores/keystore.p12"
+              type="PKCS12"/>	
+    <ssl id="defaultSSLConfig" keyStoreRef="defaultKeyStore" trustDefaultCerts="true" sslProtocol="TLSv1.2"/>
 
     <httpendpoint />
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
This is the counterpart of PR https://github.com/kabanero-io/kabanero-operator/pull/586. 
Both this PR and the mentioned PR 586 allow the console to use a secure Route with reencrypt TLS termination. This change will require some orchestration with PR 586 as the changes are interdependent.
#### Were the changes tested on
- [x ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
