### PR TITLE
add the keystore if it exists in the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,13 +69,14 @@ ENV PRODUCT_VERSION="$PRODUCT_VERSION"
 
 USER root
 
-COPY src/main/wlp/etc/social_login.xml /etc/social_login/
+COPY src/main/wlp/etc/social_login.xml /etc/console_config/social_login/
+COPY src/main/wlp/etc/keystore.xml /etc/console_config/keystore/
 
 # Symlink servers directory for easier mounts.
-# Change /etc/social_login permissions so that group 0 can access it
+# Change /etc/console_config permissions so that group 0 can access it
 RUN ln -s /opt/ol/wlp/usr/servers /servers && \
-    chgrp -R 0 /etc/social_login && \
-    chmod -R g=u /etc/social_login
+    chgrp -R 0 /etc/console_config && \
+    chmod -R g=u /etc/console_config
 
 USER 1001
 

--- a/scripts/entry_liberty_config.sh
+++ b/scripts/entry_liberty_config.sh
@@ -2,7 +2,12 @@
 # This script exists to configure the liberty server before starting it up
 
 DEFAULT_CONFIG_DROPIN_PATH='/opt/ol/wlp/usr/servers/defaultServer/configDropins/defaults/'
-SL_CONFIG_FILE='/etc/social_login/social_login.xml'
+OVERRIDE_CONFIG_DROPIN_PATH='/opt/ol/wlp/usr/servers/defaultServer/configDropins/overrides/'
+
+SL_CONFIG_FILE='/etc/console_config/social_login/social_login.xml'
+
+KEYSTORE_FILE='/etc/tls/secrets/java.io/landingpage/keystores/keystore.p12'
+KEYSTORE_CONFIG_FILE='/etc/console_config/keystore/keystore.xml'
 
 # Handle the social login feature if the GitHub OAuth secret was mounted
 if [ -f /etc/oauth/clientID ] && [ -f /etc/oauth/clientSecret ]; then
@@ -21,6 +26,11 @@ if [ -f /etc/oauth/clientID ] && [ -f /etc/oauth/clientSecret ]; then
     sed -i -e "s;{{AUTHORIZATION_ENDPOINT}};$AUTHORIZATION_ENDPOINT;g" $SL_CONFIG_FILE
 
     mv $SL_CONFIG_FILE $DEFAULT_CONFIG_DROPIN_PATH
+fi
+
+# Add keystore and ssl config if the keystore file exists in the container
+if [ -f "$KEYSTORE_FILE" ]; then
+    mv $KEYSTORE_CONFIG_FILE $OVERRIDE_CONFIG_DROPIN_PATH
 fi
 
 # Start the liberty server

--- a/src/main/wlp/etc/keystore.xml
+++ b/src/main/wlp/etc/keystore.xml
@@ -1,0 +1,7 @@
+<server>
+    <keyStore id="defaultKeyStore" 
+              password="changeit" 
+              location="/etc/tls/secrets/java.io/landingpage/keystores/keystore.p12"
+              type="PKCS12"/>
+    <ssl id="defaultSSLConfig" keyStoreRef="defaultKeyStore" trustDefaultCerts="true" sslProtocol="TLSv1.2"/>
+</server>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
closes #213 

Add the keystore server.xml config, but only if it exists at a specific mount.

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
