### PR TITLE
use 0.8.0 operator binding release instead of snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
+    <!--
     <repositories>
         <repository>
             <id>oss.sonatype.org-snapshot</id>
@@ -26,7 +27,8 @@
             </snapshots>
         </repository>
     </repositories>
-
+    -->
+    
     <dependencies>
         <dependency>
             <groupId>javax.ws.rs</groupId>
@@ -83,7 +85,7 @@
         <dependency>
             <groupId>io.kabanero</groupId>
             <artifactId>operator-java-bindings</artifactId>
-            <version>0.8.0-SNAPSHOT</version>
+            <version>0.8.0</version>
         </dependency>
         <!-- BEGIN: Needed to compile and run unit tests -->
         <dependency>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
