### PR TITLE
Fix cr link, quicker login check, and fix sync stacks button

### DIFF
--- a/src/main/content/_assets/css/stacks.scss
+++ b/src/main/content/_assets/css/stacks.scss
@@ -11,13 +11,10 @@ $kabanero-color: #C43804;
     }
 }
 
-#sync-stacks-icon{
+.sync-stacks-icon{
     cursor: pointer;
     outline: none !important;
     fill: #080808;
-}
-
-.sync-stacks-button{
     float: right;
     margin-right: 15px;
     margin-bottom: 10px;

--- a/src/main/content/_assets/js/stacks.js
+++ b/src/main/content/_assets/js/stacks.js
@@ -110,7 +110,11 @@ function updateStackView(instanceJSON, stackJSON) {
     }
 
     // Stack governance policy will help us know whether to display a digest error/warning/none when the digest mismatches on the stack
-    let policy = instanceJSON.spec.governancePolicy.stackPolicy;
+    let policy = "governance policy does not exist";
+
+    if(instanceJSON.spec && instanceJSON.spec.governancePolicy){
+        policy = instanceJSON.spec.governancePolicy.stackPolicy;
+    };
 
     // yaml metadata in kube, cannot be deactivated and has no status.
     let curatedStacks = stackJSON["curated stacks"];
@@ -313,8 +317,10 @@ function loginViaCLI(instanceName) {
 function displayDigest(instance){
     if(!instance.spec || !instance.spec.governancePolicy){
         console.log("Failed to get stack govern policy. instance.spec or instance.spec.governancePoliy does not exist.");
+        $("#stack-govern-value-text").text("not set");
         return;
     }
+
     // The way carbon dropdown works is different than normal select. 
     // This gets the current li that the server says is the current digest, and sets the display to that text.
     // Then it adds the selected class since it doesn't make sense to select the same li that is already the current digest.

--- a/src/main/content/_assets/js/stacks.js
+++ b/src/main/content/_assets/js/stacks.js
@@ -283,9 +283,9 @@ function handleInitialCLIAuth(instanceJSON, retries) {
     let instanceName = instanceJSON.metadata.name;
 
     retries = typeof retries === "undefined" ? 0 : retries;
-    // We use the stacks endpoint to check if a user is logged in on initial page load, if we get a 401 we'll login and retry this route
+    // We use the CLI version endpoint to check if a user is logged in on initial page load, if we get a 401 we'll login and retry this route
     // If we get back a 200 we consider ourselves successfully logged in
-    return fetch(`/api/auth/kabanero/${instanceName}/stacks`)
+    return fetch(`/api/auth/kabanero/${instanceName}/stacks/version`)
         .then(function (response) {
             // Login via cli and retry if 401 is returned on initial call
             if (retries <= CLI_LOGIN_RETRY_COUNT && response.status === 401) {

--- a/src/main/content/_assets/js/stacks.js
+++ b/src/main/content/_assets/js/stacks.js
@@ -12,12 +12,10 @@ $(document).ready(function () {
     fetchAnInstance(instanceName)
         .then(loadAllInfo);
 
-    $("#sync-stacks-icon").on("click", (e) => {
-        if (e.target.getAttribute("class") == "icon-active") {
-            let instanceName = getActiveInstanceName();
-            emptyTable();
-            syncStacks(instanceName);
-        }
+    $(".sync-stacks-icon").on("click", (e) => {
+        let instanceName = getActiveInstanceName();
+        emptyTable();
+        syncStacks(instanceName);
     });
 
     $("#stack-table-body").on("click", ".deactivate-stack-icon", e => {

--- a/src/main/content/index.html
+++ b/src/main/content/index.html
@@ -115,7 +115,7 @@ seo-title: Kabanero
                 <li  id="dev-tools-codready-install-steps">
                     {{t.index.devtools.steps.follow-steps}}
                     <a target="_blank"
-                        href="/docs/ref/general/installation/installing-codeready-and-codewind">{{t.index.devtools.steps.codereadyInstall}}</a>
+                        href="/docs/ref/general/installation/installing-codeready-and-codewind.html">{{t.index.devtools.steps.codereadyInstall}}</a>
                 </li>
             </ul>
 

--- a/src/main/content/stacks.html
+++ b/src/main/content/stacks.html
@@ -77,7 +77,7 @@ permalink: /instance/stacks/
                 <div class="bx--col-xlg">
                     <div id="stack-table-container">
                         <!-- Sync stack refresh icon -->
-                        <div class="sync-stacks-button">
+                        <div class="sync-stacks-icon">
                             <button
                                 class="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--left bx--tooltip--align-start">
                                 <span class="bx--assistive-text">{{t.instance.sync-tooltip}}</span>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

Fix a bum link

use the /version login to check if we're logged in since /stacks endpoint takes awhile and we want to know asap

fix the sync stacks button because it didn't trigger any call

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
