### PR TITLE
handle CLI JSON with missing images array

### DIFF
--- a/src/main/content/_assets/js/stacks.js
+++ b/src/main/content/_assets/js/stacks.js
@@ -166,11 +166,14 @@ function updateStackView(instanceJSON, stackJSON) {
         versions.forEach(version => {
             let name = $("<td>").text(stack.name);
             let versionTD = $("<td>").text(version.version);
-            let images = version.images.reduce((acc, imageObj) => {
-                return acc += `${imageObj.image}<br/>`;
-            }, "");
 
-            let imagesTD = $("<td>").html(images);
+            let imagesTD = $("<td>").text("Not Available");
+            if(version.images){
+                let images = version.images.reduce((acc, imageObj) => {
+                    return acc += `${imageObj.image}<br/>`;
+                }, "");
+                imagesTD = $("<td>").html(images);
+            }
             let row = $("<tr>").append([name, versionTD, imagesTD]);
             rows.push(row);
         });


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

closes #240 

CLI didn't return an expected JSON key so we failed parsing it. Make the parsing more resilient.

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
