### PR TITLE
Suppress warning messages on governance for invalid stacks

### DIFF
--- a/src/main/content/_assets/js/stacks.js
+++ b/src/main/content/_assets/js/stacks.js
@@ -149,11 +149,11 @@ function updateStackView(instanceJSON, stackJSON) {
             let statusTD = $("<td>").text(statusItem.status);
             let deactivateStack = createDeactivateStackButton(stack.name, statusItem.status, statusItem.version);
             let row = $("<tr>").append([name, versionTD, statusTD, deactivateStack]);
-            rows.push(row);
+            rows.push(row); 
 
             // The error (one long colspan td) will appear under the row it 
             // references so that is why we append this new row after the row with all the info above
-            let digestError = statusItem["digest check"] && (statusItem["digest check"] !== DIGEST_MATCHED) ? getDigestError(stack.name, statusItem) : "";
+            let digestError = statusItem["digest check"] && (statusItem["digest check"] !== DIGEST_MATCHED) && (stack.status === "active") ? getDigestError(stack.name, statusItem) : "";
             rows.push(digestError);
         });
         return rows;

--- a/src/main/content/_assets/js/stacks.js
+++ b/src/main/content/_assets/js/stacks.js
@@ -110,7 +110,7 @@ function updateStackView(instanceJSON, stackJSON) {
     if (typeof instanceJSON === "undefined" || typeof stackJSON === "undefined") {
         return;
     }
-
+ 
     // Stack governance policy will help us know whether to display a digest error/warning/none when the digest mismatches on the stack
     let policy = "governance policy does not exist";
 
@@ -153,7 +153,7 @@ function updateStackView(instanceJSON, stackJSON) {
 
             // The error (one long colspan td) will appear under the row it 
             // references so that is why we append this new row after the row with all the info above
-            let digestError = statusItem["digest check"] && (statusItem["digest check"] !== DIGEST_MATCHED) && (stack.status === "active") ? getDigestError(stack.name, statusItem) : "";
+            let digestError = statusItem["digest check"] && (statusItem["digest check"] !== DIGEST_MATCHED) && (statusItem.status === "active") ? getDigestError(stack.name, statusItem) : "";
             rows.push(digestError);
         });
         return rows;


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
closes: #241 
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
